### PR TITLE
fix(cloudwatch-metrics-stream): initialize aws_partition datasource

### DIFF
--- a/modules/cloud-watch-metrics-stream/data.tf
+++ b/modules/cloud-watch-metrics-stream/data.tf
@@ -1,2 +1,3 @@
 data "aws_region" "current" {}
 data "aws_caller_identity" "me" {}
+data "aws_partition" "current" {}


### PR DESCRIPTION
Add missing `aws_partition` datasource inizialization in the `Cloudwatch Metrics Stream` module.