### PR TITLE
fix(cloudwatch-metrics-stream): remove unused permissions from cloud_monitoring_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,6 @@ Sysdig requires AWS IAM permissions to display the correct status and metadata f
 	"Statement": [
 		{
 			"Action": [
-				"s3:ListBucket",
-				"s3:GetObjectAttributes",
-				"s3:GetObject"
-			],
-			"Effect": "Allow",
-			"Resource": "arn:aws:s3:::sysdig-backup-bucket*"
-		},
-		{
-			"Action": [
-				"cloudwatch:ListMetricStreams",
-				"cloudwatch:GetMetricStream"
-			],
-			"Effect": "Allow",
-			"Resource": "arn:aws:cloudwatch:*:<AWS-accountID>:metric-stream/*"
-		},
-		{
-			"Action": "firehose:DescribeDeliveryStream",
-			"Effect": "Allow",
-			"Resource": "arn:aws:firehose:*:<AWS-accountID>:deliverystream/*"
-		},
-		{
-			"Action": [
 				"cloudwatch:ListMetrics",
 				"cloudwatch:GetMetricData"
 			],
@@ -56,14 +34,6 @@ Sysdig requires AWS IAM permissions to display the correct status and metadata f
 		},
 		{
 			"Action": "ec2:DescribeInstances",
-			"Effect": "Allow",
-			"Resource": "*"
-		},
-		{
-			"Action": [
-				"s3:ListBucket",
-				"s3:ListAllMyBuckets"
-			],
 			"Effect": "Allow",
 			"Resource": "*"
 		}

--- a/modules/cloud-watch-metrics-stream/iam_data.tf
+++ b/modules/cloud-watch-metrics-stream/iam_data.tf
@@ -79,38 +79,6 @@ data "aws_iam_policy_document" "sysdig_cloudwatch_integration_monitoring_role_as
 }
 
 data "aws_iam_policy_document" "iam_role_task_policy_cloud_monitoring_policy" {
-    statement {
-        effect = "Allow"
-        actions = [
-            "s3:ListBucket",
-            "s3:GetObject",
-            "s3:GetObjectAttributes"
-        ]
-        resources = [
-            "arn:${data.aws_partition.current.partition}:s3:::sysdig-backup-bucket*"
-        ]
-    }
-
-    statement {
-        effect = "Allow"
-        actions = [
-            "cloudwatch:GetMetricStream",
-            "cloudwatch:ListMetricStreams"
-        ]
-        resources = [
-            "arn:${data.aws_partition.current.partition}:cloudwatch:*:${data.aws_caller_identity.me.account_id}:metric-stream/*"
-        ]
-    }
-
-    statement {
-        effect = "Allow"
-        actions = [
-            "firehose:DescribeDeliveryStream"
-        ]
-        resources = [
-            "arn:${data.aws_partition.current.partition}:firehose:*:${data.aws_caller_identity.me.account_id}:deliverystream/*"
-        ]
-    }
 
     statement {
         effect = "Allow"
@@ -133,14 +101,4 @@ data "aws_iam_policy_document" "iam_role_task_policy_cloud_monitoring_policy" {
         ]
     }
 
-    statement {
-        effect = "Allow"
-        actions = [
-            "s3:ListAllMyBuckets",
-            "s3:ListBucket"
-        ]
-        resources = [
-            "*"
-        ]
-    }
 }


### PR DESCRIPTION
Remove the unused permission from the cloud_monitoring_policy:
* s3:ListBucket
* s3:GetObjectAttributes
* s3:GetObject
* cloudwatch:ListMetricStreams
* cloudwatch:GetMetricStream
* firehose: DescribeDeliveryStream
* s3:ListBucket
* s3:ListAllMyBuckets